### PR TITLE
17419: Fix workflow for release builds

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -20,7 +20,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     outputs:
-      package-version: ${{ steps.get-version.package-version }}
+      package-version: ${{ steps.get-version.outputs.package-version }}
     steps:
 
       - uses: actions/checkout@v3
@@ -40,7 +40,6 @@ jobs:
         run: |
           node -e "console.log('package-version=' + require('./package.json').version)" >> $GITHUB_OUTPUT
           node -e "console.log('PACKAGE_VERSION=' + require('./package.json').version)" >> $GITHUB_ENV
-          echo "Got version: ${{ env.PACKAGE_VERSION }}"
 
       - name: Package
         run: |


### PR DESCRIPTION
Fixed an issue where the output from the `build-test-package` workflow was not being sent to `release`.