### PR TITLE
20408: Corrected debugger line numbers for non-versioned Amalgam builds

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "amalgam-lang",
-    "version": "1.2.0",
+    "version": "1.2.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "amalgam-lang",
-            "version": "1.2.0",
+            "version": "1.2.1",
             "license": "AGPL-3.0-only",
             "dependencies": {
                 "@vscode/debugadapter": "^1.59.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "amalgam-lang",
-    "version": "1.2.0",
+    "version": "1.2.1",
     "type": "commonjs",
     "publisher": "howso",
     "displayName": "Amalgam Language",

--- a/src/debugger/session.ts
+++ b/src/debugger/session.ts
@@ -503,7 +503,7 @@ export class AmalgamDebugSession extends LoggingDebugSession {
     try {
       const executableVersion = await this.getExecutableVersion(executable);
       outputLogger.info(`Amalgam Version: ${executableVersion}`);
-      if (semver.lt(executableVersion, "50.0.2")) {
+      if (semver.gt(executableVersion, "0.0.0") && semver.lt(executableVersion, "50.0.2")) {
         this.setDebuggerLinesStartAt1(false);
         this.setDebuggerColumnsStartAt1(false);
         outputLogger.debug("Line numbers set to 0-based");


### PR DESCRIPTION
If the Amalgam version is `0.0.0` use 1-based line numbers instead of 0-based.