### PR TITLE
25266: Updates debugger to show last opcode return value in variables scope, MINOR

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "amalgam-lang",
-    "version": "3.1.1",
+    "version": "3.2.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "amalgam-lang",
-            "version": "3.1.1",
+            "version": "3.2.0",
             "license": "AGPL-3.0-only",
             "dependencies": {
                 "@vscode/debugadapter": "^1.68.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "amalgam-lang",
-    "version": "3.1.1",
+    "version": "3.2.0",
     "type": "commonjs",
     "publisher": "howso",
     "displayName": "Amalgam Language",

--- a/src/debugger/runtime.ts
+++ b/src/debugger/runtime.ts
@@ -1,4 +1,5 @@
 import { spawn, ChildProcessWithoutNullStreams } from "child_process";
+import { DebugProtocol } from "@vscode/debugprotocol";
 import { EventEmitter } from "events";
 import { platform } from "os";
 import { queue, QueueObject } from "async";
@@ -86,6 +87,7 @@ export type IRuntimeCommand =
   | "c"
   | "f"
   | "fc"
+  | "r"
   | "s"
   | "n"
   | "br"
@@ -112,8 +114,8 @@ export interface IRuntimeTask {
 /** The result of a runtime command */
 export type IRuntimeResult<T extends IRuntimeCommand = IRuntimeCommand> = T extends "stack"
   ? { type: "stack"; stack: IRuntimeStack | undefined }
-  : T extends "eval" | "pv" | "pp" | "p" | "entity"
-  ? { type: "eval" | "pv" | "pp" | "p" | "entity"; value: string | undefined }
+  : T extends "eval" | "pv" | "pp" | "p" | "r" | "entity"
+  ? { type: "eval" | "pv" | "pp" | "p" | "r" | "entity"; value: string | undefined }
   : T extends "vars" | "labels" | "entities"
   ? { type: "vars" | "labels" | "entities"; values: string[] }
   : T extends "bn"
@@ -129,6 +131,7 @@ export type IRuntimeVariableCategory = "var" | "label" | "entity";
 
 export class RuntimeVariable {
   public reference?: number;
+  public presentationHint?: Omit<DebugProtocol.VariablePresentationHint, "lazy">;
   public readonly category: IRuntimeVariableCategory = "var";
 
   public get value() {
@@ -188,8 +191,8 @@ export class AmalgamRuntime extends EventEmitter {
     // Breakpoints and stack are matched via the header line and existing subsequent nested lines
     breakpoints: /^(?<type>Line) Breakpoints:\n(?<brs>^(?:\s{2}.+)+)$/gm,
     stack: /^(?<type>Interpret node|Opcode) stack:\n(?<frames>^(?:\s{2}.+)+)$/gm,
-    // Expression results match all lines up to final empty line
-    expression: /^(?<value>[\s\S]+)\n{2}$/gm,
+    // Expression results match all lines
+    expression: /^(?<value>[\s\S]+)$/gm,
     // Results match all lines starting with 2 spaces
     lines: /^ {2}(?<line>.+)$/gm,
   };
@@ -395,7 +398,8 @@ export class AmalgamRuntime extends EventEmitter {
       let { values } = await this.sendCommand("vars", signal);
       values = Array.from(new Set(values)).sort();
 
-      return await Promise.all(
+      // Get value preview for all variables
+      const variables = await Promise.all(
         values.map(async (v) => {
           let { value } = await this.sendCommand("pp", signal, v);
           if (value != null) {
@@ -405,6 +409,12 @@ export class AmalgamRuntime extends EventEmitter {
           return new RuntimeVariable(v, value);
         })
       );
+
+      // Get the last opcode return value
+      const returnValue = await this.getReturnValue();
+      variables.push(returnValue);
+
+      return variables;
     } catch (err) {
       if (err instanceof RuntimeCommandCancelled) {
         return [];
@@ -521,6 +531,17 @@ export class AmalgamRuntime extends EventEmitter {
   public async evaluate(expression: string): Promise<RuntimeVariable> {
     const { value } = await this.sendCommand("eval", prepareExpression(expression));
     return new RuntimeVariable("eval", value);
+  }
+
+  /**
+   * Get the previous opcode's return value.
+   * @returns The return value.
+   */
+  public async getReturnValue(): Promise<RuntimeVariable> {
+    const { value } = await this.sendCommand("r");
+    const rv = new RuntimeVariable("[return value]", value);
+    rv.presentationHint = { kind: "virtual", visibility: "internal", attributes: ["readOnly"] };
+    return rv;
   }
 
   /**
@@ -762,7 +783,7 @@ export class AmalgamRuntime extends EventEmitter {
 
     // Match expression
     let expressionResult: string | undefined = undefined;
-    if (["p", "pv", "pp", "eval", "entity"].indexOf(command) >= 0) {
+    if (["p", "pv", "pp", "r", "eval", "entity"].indexOf(command) >= 0) {
       reg = new RegExp(this.matchers.expression);
       while ((matches = reg.exec(lines)) != null) {
         if (matches.groups) {
@@ -894,6 +915,7 @@ export class AmalgamRuntime extends EventEmitter {
       case "p":
       case "pv":
       case "pp":
+      case "r":
       case "entity":
       case "eval": {
         this.commandDone.notify({

--- a/src/debugger/session.ts
+++ b/src/debugger/session.ts
@@ -241,7 +241,7 @@ export class AmalgamDebugSession extends LoggingDebugSession {
 
     switch (args.context) {
       case "repl": {
-        const CMD_REGEXP = /^~(?<cmd>entities)(?: (?<args>.+))?$/i;
+        const CMD_REGEXP = /^~(?<cmd>entities|return)(?: (?<args>.+))?$/i;
         const match = CMD_REGEXP.exec(args.expression);
         if (match?.groups) {
           // Handle custom commands
@@ -249,6 +249,10 @@ export class AmalgamDebugSession extends LoggingDebugSession {
             case "entities": {
               const entities = await this.runtime.getEntities();
               reply = entities.map((e) => e.name).join("\n");
+              break;
+            }
+            case "return": {
+              rv = await this.runtime.getReturnValue();
               break;
             }
           }
@@ -449,6 +453,11 @@ export class AmalgamDebugSession extends LoggingDebugSession {
           detail: "Print out the contained entities.",
           type: "method",
         },
+        {
+          label: "return",
+          detail: "Print out the value returned by the previous opcode.",
+          type: "method",
+        },
       ],
     };
     this.sendResponse(response);
@@ -635,13 +644,15 @@ export class AmalgamDebugSession extends LoggingDebugSession {
       value: "???",
       variablesReference: 0,
       evaluateName: `${variable.category} ${variable.name}`,
+      presentationHint: { ...variable.presentationHint },
     };
     if (variable.lazy) {
       variable.reference ??= this._variableHandles.create(variable);
       dapVariable.variablesReference = variable.reference;
       dapVariable.value = "";
       dapVariable.presentationHint = {
-        lazy: variable.lazy,
+        ...dapVariable.presentationHint,
+        lazy: true,
       };
     } else {
       if (Array.isArray(variable.value)) {


### PR DESCRIPTION
- Adds debug console command `~return` to manually request the current last opcode return value.
- Adds readonly `[return value]` field in the variables scope